### PR TITLE
Revert filter change

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -61,7 +61,7 @@ impl Filter {
 
     pub fn wants_account(&self, account: &[u8]) -> bool {
         match <&[u8; 32]>::try_from(account) {
-            Ok(key) => self.account_filters.is_empty() || self.account_filters.contains(key),
+            Ok(key) => self.account_filters.contains(key),
             Err(_error) => true,
         }
     }


### PR DESCRIPTION
Reverts filter change which gave cause to a bug that meant that program_ignores wouldnt work for account updates.